### PR TITLE
fix: support XC_USER authentication required by newer MiniSafe2 firmwares

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ Example:
 http://192.168.178.123/cmd?XC_FNC=GetStates&XC_PASS=MyKillerPassword 
 ```
 
+> **Note:** Newer firmwares with activated Eltako cloud access (seen with C2/1.26.5) additionally require `XC_USER=...` with the e-mail address of the Eltako account. Without it, every request is answered with `{"XC_ERR":{"code":"000007","msg":"access denied"}}` — see [#17](https://github.com/awaescher/homebridge-eltako-minisafe2/issues/17). The plugin supports this with the optional `username` setting. Username and password have to be url-encoded if they contain special characters, the plugin does this automatically.
+
 The GFA5 app is using the access token instead of the password. You can sniff your network traffic for the access token but I don't know how long it will be valid.
 
 |Route|Function|

--- a/config.schema.json
+++ b/config.schema.json
@@ -18,6 +18,13 @@
         "required": true,
         "placeholder": "192.168.1.1"
       },
+      "username": {
+        "title": "The username (Eltako account e-mail) to access the MiniSafe2",
+        "description": "Required on newer firmwares if cloud access is activated - the MiniSafe2 then expects XC_USER in addition to the password.",
+        "type": "string",
+        "required": false,
+        "default": ""
+      },
       "password": {
         "title": "The password to access the MiniSafe2",
         "description": "Can be left empty if an access token is used",

--- a/src/MiniSafe2Api.ts
+++ b/src/MiniSafe2Api.ts
@@ -8,6 +8,7 @@ export class MiniSafe2Api {
     private readonly gatewayIp: string,
     private readonly gatewayPassword: string,
     private readonly gatewayAccessToken: string,
+    private readonly gatewayUsername?: string,
   ) {
     if (!gatewayIp) {
       throw new Error('Gateway ip cannot be empty');
@@ -22,6 +23,12 @@ export class MiniSafe2Api {
     const url = this.buildUrl('/file/config/iqpro/systems.json');
 
     const response = await axios.get<SystemConfig>(url);
+
+    if (!Array.isArray(response.data?.devices)) {
+      throw new Error('Gateway did not return the system configuration (devices missing). Raw response: '
+        + this.describeResponse(response.data));
+    }
+
     return response.data;
   }
 
@@ -39,7 +46,21 @@ export class MiniSafe2Api {
     const url = this.buildUrl('/cmd?XC_FNC=GetStates');
 
     const response = await axios.get<DeviceResponse>(url, { timeout: 3000 });
+
+    if (!Array.isArray(response.data?.XC_SUC)) {
+      throw new Error('Gateway did not return device states (XC_SUC missing). Raw response: ' + this.describeResponse(response.data));
+    }
+
     return response.data.XC_SUC;
+  }
+
+  private describeResponse(data: unknown): string {
+    try {
+      const text = typeof data === 'string' ? data : JSON.stringify(data);
+      return (text ?? 'empty response').substring(0, 300);
+    } catch {
+      return 'unserializable response';
+    }
   }
 
 
@@ -81,11 +102,13 @@ export class MiniSafe2Api {
     const separator = route.includes('?') ? '&' : '?';
 
     if (this.gatewayPassword) {
-      return `http://${this.gatewayIp}${route}${separator}XC_PASS=${this.gatewayPassword}`;
+      // Newer firmwares with activated cloud access require XC_USER (the Eltako account e-mail) in addition to XC_PASS
+      const user = this.gatewayUsername ? `XC_USER=${encodeURIComponent(this.gatewayUsername)}&` : '';
+      return `http://${this.gatewayIp}${route}${separator}${user}XC_PASS=${encodeURIComponent(this.gatewayPassword)}`;
     }
 
     if (this.gatewayAccessToken) {
-      return `http://${this.gatewayIp}${route}${separator}at=${this.gatewayAccessToken}`;
+      return `http://${this.gatewayIp}${route}${separator}at=${encodeURIComponent(this.gatewayAccessToken)}`;
     }
 
     throw new Error('Neither the gateway password nor an alternative access token was given.');

--- a/src/__tests__/MiniSafe2Api.test.ts
+++ b/src/__tests__/MiniSafe2Api.test.ts
@@ -1,0 +1,36 @@
+import {expect} from 'chai';
+import {MiniSafe2Api} from '../MiniSafe2Api';
+
+describe('MiniSafe2Api related tests', () => {
+  describe('buildUrl related tests', () => {
+    it('should authenticate with XC_PASS only when no username is set', () => {
+      const api = new MiniSafe2Api('192.168.1.2', 'secret', '');
+      const url = api.buildUrl('/cmd?XC_FNC=GetStates');
+      expect(url).to.equal('http://192.168.1.2/cmd?XC_FNC=GetStates&XC_PASS=secret');
+    });
+
+    it('should prepend XC_USER when a username is set', () => {
+      const api = new MiniSafe2Api('192.168.1.2', 'secret', '', 'user@example.com');
+      const url = api.buildUrl('/cmd?XC_FNC=GetStates');
+      expect(url).to.equal('http://192.168.1.2/cmd?XC_FNC=GetStates&XC_USER=user%40example.com&XC_PASS=secret');
+    });
+
+    it('should url-encode special characters in the password', () => {
+      const api = new MiniSafe2Api('192.168.1.2', 'p@ss wort', '');
+      const url = api.buildUrl('/info');
+      expect(url).to.equal('http://192.168.1.2/info?XC_PASS=p%40ss%20wort');
+    });
+
+    it('should url-encode the access token', () => {
+      const api = new MiniSafe2Api('192.168.1.2', '', 'tok/en+1');
+      const url = api.buildUrl('/info');
+      expect(url).to.equal('http://192.168.1.2/info?at=tok%2Fen%2B1');
+    });
+
+    it('should use ? as separator for routes without a query string', () => {
+      const api = new MiniSafe2Api('192.168.1.2', 'secret', '', 'user@example.com');
+      const url = api.buildUrl('/info');
+      expect(url).to.equal('http://192.168.1.2/info?XC_USER=user%40example.com&XC_PASS=secret');
+    });
+  });
+});

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -48,7 +48,7 @@ export class EltakoMiniSafe2Platform implements DynamicPlatformPlugin {
       this.log.info('Connecting to Eltako MiniSafe2 on ' + this.config.ip);
 
       try {
-        this.miniSafe = new MiniSafe2Api(this.config.ip, this.config.password, this.config.accessToken);
+        this.miniSafe = new MiniSafe2Api(this.config.ip, this.config.password, this.config.accessToken, this.config.username);
         await this.updateDeviceStateCache();
         await this.discoverDevices();
       } catch (e) {


### PR DESCRIPTION
## Problem

Newer MiniSafe2 firmwares with activated Eltako cloud access (seen with C2 / 1.26.5) no longer accept `XC_PASS`-only authentication. Every endpoint answers with `{"XC_ERR":{"code":"000007","msg":"access denied"}}` — also without credentials or with a wrong password, so the API looks completely dead. The plugin then runs into the misleading `newDevices is not iterable` log loop and no devices are loaded (#17, most likely also #14).

The GFA5 app is not affected because it authenticates with the `at=` access token.

## Verification against a real device (C2 / 1.26.5, cloud access activated)

- `XC_PASS` raw and url-encoded → access denied
- `auth=` parameter (from Eltako's "HTTP Kommandos" PDF) → access denied
- no credentials / wrong password → identical access denied
- gateway reboot → no change
- `XC_USER=<eltako account e-mail>&XC_PASS=<password>` → `XC_SUC` with the full device list

## Changes

- New optional `username` setting (`config.schema.json`), sent as `XC_USER` — setups without a username keep the exact current behavior
- `buildUrl()` url-encodes username, password and access token (Eltako's own PDF points out that special characters must be url-encoded)
- `getStates()`/`getSystems()` validate the response shape and throw with the actual (truncated) gateway response, so the log shows the root cause instead of `newDevices is not iterable`
- Unit tests for `buildUrl`, README note about the new firmware behavior

`npm run lint`, `npm run build` and all tests (6 existing + 5 new) pass. Running on my device since today — all devices are back in HomeKit.

Fixes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)
